### PR TITLE
Click first login link

### DIFF
--- a/lib/mfynab/cli.rb
+++ b/lib/mfynab/cli.rb
@@ -55,7 +55,7 @@ class CLI
       @session.visit("https://moneyforward.com/")
 
       puts "Clicking login button"
-      @session.click_on("ログイン")
+      @session.first(:link, "ログイン").trigger("click")
 
       puts "Filling in username"
       @session.fill_in("メールアドレス", with: config["moneyforward_username"])


### PR DESCRIPTION
## What

Fixes the following error:

```
Ambiguous match, found 2 elements matching visible css "a" with text "ログイン" (Capybara::Ambiguous)
```

## Why

Moneyforward now has multiple "Login" links in the HTML, presumably to
support the mobile view:

<img src=https://github.com/davidstosik/moneyforward_ynab/assets/104138/c50826ab-14ff-467e-babd-f801918d6cc1 width=40%>

