### PR TITLE
properly show YNAB import errors

### DIFF
--- a/lib/mfynab/cli.rb
+++ b/lib/mfynab/cli.rb
@@ -203,7 +203,7 @@ class CLI
           begin
             ynab_api.transactions.create_transactions(budget.id, wrapper)
           rescue StandardError => e
-            puts "Error importing transactions for #{mf_account}: #{e}"
+            puts "Error importing transactions for #{budget.name}. #{e} : #{e.detail}"
           end
         end
       end


### PR DESCRIPTION
## What

Fixes variable name and adds more detail to output.

## Why

This was failing with:

```
(NameError)
puts "Error importing transactions for #{mf_account}: #{e}"
                                         ^^^^^^^^^^
```

Fixing that revealed the error:

```
Error importing transactions for Budget Name: Bad Request
```

Adding in `detail` gives a bit more info:

```
Error importing transactions for Budget Name. Bad Request : import_id is too long (maximum is 36 characters) (index: 0), import_id is too long (maxim....
```
