### PR TITLE
Keep IDs within YNAB limit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "base62-rb"
 gem "capybara", "~> 3.39"
 gem "cuprite", "~> 0.14.3"
 gem "debug", "~> 1.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ GEM
   specs:
     addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
+    base62-rb (0.3.1)
     capybara (3.39.2)
       addressable
       matrix
@@ -34,6 +35,8 @@ GEM
     matrix (0.4.2)
     mini_mime (1.1.5)
     nokogiri (1.15.4-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.15.4-x86_64-darwin)
       racc (~> 1.4)
     psych (5.1.0)
       stringio
@@ -68,8 +71,10 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  x86_64-darwin-23
 
 DEPENDENCIES
+  base62-rb
   capybara (~> 3.39)
   cuprite (~> 0.14.3)
   debug (~> 1.8)


### PR DESCRIPTION
## What

Hashes the IDs to keep them within the YNAB 36 char limit.

### Before

```
MFBY:v1:vyAQJC_b3oUWJf2OLF-3JcklMtvnSRW-YCJgWoLnEJQ
```

### After

```
Pl0oysmdCA6kFEA6OQK87oSUK8mav8wTWIGE
```

## Why

I was running into the following error when importing to YNAB:

```
import_id is too long (maximum is 36 characters)
```

## How

This is definitely not my wheelhouse, and I relied on Google / AI voodoo to arrive at this solution. 😅 
From what I can tell, this _should_ guarantee enough uniqueness at this scale, but I'm by no means an expert. 🤡 