### PR TITLE
Shorten memo

### DIFF
--- a/lib/mfynab/cli.rb
+++ b/lib/mfynab/cli.rb
@@ -185,7 +185,6 @@ class CLI
 
           transactions = @mf_data[mapping["money_forward_name"]].map do |row|
             import_id = "MFBY:v1:#{row["id"]}"
-            memo = "#{row["category"]}/#{row["subcategory"]} - #{row["content"]} - #{row["memo"]}"
 
             {
               account_id: account.id,
@@ -193,7 +192,7 @@ class CLI
               payee_name: row["content"][0, 100],
               date: Date.strptime(row["date"], "%Y/%m/%d").strftime("%Y-%m-%d"),
               cleared: "cleared",
-              memo: memo,
+              memo: row["memo"],
               import_id: import_id,
             }
           end


### PR DESCRIPTION
## Why

YNAB wouldn't accept the longer custom memo:

```
Bad Request : memo is too long (maximum is 200 characters) (index: 63), memo is too long...
```

## How

Not sure how you're making use of the memo, so this might not be the
best way to about it! 

I've just pointed the `memo` row from MoneyForward to YNABs `memo`.

For me, these are probably always going to be blank 😅 , but if the previous
memo was useful, we'd need to shorten it somehow (did YNAB add a bunch of
new validations I wonder? 🤔 )
