### PR TITLE
increase timeout

### DIFF
--- a/lib/mfynab/cli.rb
+++ b/lib/mfynab/cli.rb
@@ -39,6 +39,7 @@ class CLI
           window_size: [1200, 800],
           headless: !ENV.key?("NO_HEADLESS"),
           save_path: save_path,
+          timeout: 30,
         )
       end
 


### PR DESCRIPTION
## Why

I'm unsure if my laptop/wifi is slow, but I couldn't load the page without bumping up the timeout. 😅 

```
Timed out waiting for response. 
It's possible that this happened because something took a very long time (for example a page load was slow). 
If so, setting the :timeout option to a higher value might help. (Ferrum::TimeoutError)
```