### PR TITLE
Fix MoneyForward CSV read encoding

### DIFF
--- a/lib/mfynab/cli.rb
+++ b/lib/mfynab/cli.rb
@@ -137,7 +137,7 @@ class CLI
         CSV.foreach(
           file,
           headers: true,
-          encoding: "Shift_JIS:UTF-8",
+          encoding: "SJIS:UTF-8",
           converters: :all,
           header_converters: csv_header_converters,
         ) do |row|


### PR DESCRIPTION
CSV reading was failing on the first character for 髙島屋 (Takashimaya):

```
in `gets': "\xFB\xFC" from Shift_JIS to UTF-8 (Encoding::UndefinedConversionError)
```

(Note how 髙 and 高 are two different characters.)

Looks like `Encoding::SJIS` knows how to convert the character to UTF-8 whereas `Encoding::Shift_JIS` doesn't.
(I thought they were two aliases for the same encoding!)

Only after typing the above I found this article, which treats of
exactly this problem!
[SJISはShift_JISのエイリアスじゃない](https://developers.freee.co.jp/entry/sjis-is-not-an-alias-of-shift-jis)
