### PR TITLE
Ensure `import_id` stays within YNAB API's 36-char limit

### DIFF
--- a/config/example.yml
+++ b/config/example.yml
@@ -1,6 +1,5 @@
 David:
   ynab_budget: "My budget"
-  import_id_cutoff: 2020-01-01
   accounts:
     - money_forward_name: "楽天銀行"
       ynab_name: "Rakuten Bank"

--- a/config/example.yml
+++ b/config/example.yml
@@ -1,5 +1,6 @@
 David:
   ynab_budget: "My budget"
+  import_id_cutoff: 2020-01-01
   accounts:
     - money_forward_name: "楽天銀行"
       ynab_name: "Rakuten Bank"

--- a/lib/mfynab/cli.rb
+++ b/lib/mfynab/cli.rb
@@ -258,18 +258,21 @@ class CLI
     # amount later.
     # (I don't know what that means for cleared and reconciled transactions...)
     def generate_import_id_for(row)
-      max_length = 36
-
       # Uniquely identify transactions to avoid conflicts with other potential import scripts
       # Note: I don't remember why I named it MFBY (why not MFYNAB or MFY?),
       # but changing it now would require a lot of work in preventing import
       # duplicates due to inconsistent import_id.
       prefix = "MFBY:v1:"
 
+      max_length = 36     # YNAB API limit
+      id_max_length = 28  # this leaves 8 characters for the prefix
+
       id = row["id"]
 
+      # Only hash if the ID would exceed YNAB's limit.
+      # This improves backwards compatibility with old import_ids.
       if prefix.length + id.length > max_length
-        id = Digest::SHA256.hexdigest(id)[0, max_length - prefix.size]
+        id = Digest::SHA256.hexdigest(id)[0, id_max_length]
       end
 
       prefix + id


### PR DESCRIPTION
> [!WARNING]
>
> This PR introduces the risk of duplicating old transactions.

## What?

Change the logic employed to generate each transaction's `import_id`.

## Why?

The original logic I implemented generated IDs that could be over 36 characters, but YNAB's API (or at least the gem) limits `import_id` to 36 characters ([here](https://github.com/ynab/ynab-sdk-ruby/blob/825a49af31fa8bd10ee7406fc40bf72955a1b406/open_api_spec.yaml#L2442-L2445)).

## How?

Limiting import IDs to 36 characters is easily done: generate a digest and truncate anything that's too long.

However, the big problem is that a user updating the gem may end up trying to import transactions that were already imported before, but with a different `import_id`. This would have the consequence of creating duplicate transactions in YNAB.

To alleviate this issue I decided to change the `import_id` format only on transactions for which it would exceed the 36-character limit. This means that transactions that the script managed to import in the past will keep being imported with the same id and not produce duplicates.

<!--

I needed a way to ensure that transactions that have already been imported in a user's YNAB budget would continue being imported with the same ID, even when using a new version of the moneyforward_ynab gem.

The idea is to let the user add an `import_id_cutoff` config in their config file. Transactions older than that date would be imported with the old import_id logic while newer transactions would get imported with the new import_id logic.

Since there's still a possibility that old transactions may have an import_id that's too long long, I added truncation to the "old logic".

-->

## Anything else?

> [!CAUTION] <!-- NOTE | TIP | IMPORTANT | WARNING | CAUTION -->
>
> Note that if you had fixed the "`import_id` is too long" issue for yourself with a different logic to produce `import_id`s shorter than 36 characters, then chances are you won't be able to avoid duplicates.
>
> The first time you run the import after updating this repository, expect to see duplicate transactions within the last three months (the currently hard-coded period this script runs on).
> If you're on top of your YNAB budgeting, the best way to deal with it is to follow this procedure within a short time frame (same day?):
> 1. Run the import before updating (this will use your custom `import_id` logic).
> 2. Reconcile all the accounts synced with mfynab in your YNAB budget.
> 3. Clear your changes and update this repository.
> 4. Run mfynab to sync once more.
> 5. Identifying duplicates should be as easy as picking cleared but not reconciled transactions in the last three months.

I'm considering the implementation of a better solution that'll make it easier to change the `import_id` logic in the future (by making a list of candidates to compare with existing transactions in YNAB), but for now, please be aware of this risk.

<!--
 been using your own import_id logic for a while (after using the old import_id logic and before updating to a version that includes this fix), you might need to add your own patch to the gem until you don't need to import those older transactions anymore (since the gem is currently hard coded with a 3-month import, one would stop needing custom logic 3 months after the last import with an old version of the gem).

This is still a bit confusing I think. Maybe I should improve either this description, or figure out a better way to not introduce the problem.
-->