### PR TITLE
Add more info to exceptions

### DIFF
--- a/lib/mfynab/money_forward.rb
+++ b/lib/mfynab/money_forward.rb
@@ -66,8 +66,8 @@ module MFYNAB
         )
 
         result = http.request(request)
-        raise unless result.is_a?(Net::HTTPSuccess)
-        raise unless result.body.valid_encoding?
+        raise "Got unexpected result: #{result.inspect}" unless result.is_a?(Net::HTTPSuccess)
+        raise "Invalid encoding" unless result.body.valid_encoding?
 
         result.body.encode(Encoding::UTF_8)
       end


### PR DESCRIPTION
## What

Turns this:

```
money_forward.rb:69:in `block in download_csv_string':
unhandled exception
```


Into this:

```
money_forward.rb:69:in `block in download_csv_string': 
Got unexpected result: #<Net::HTTPFound 302 Found readbody=true> (RuntimeError)
```

## Why

I started running into these redirect errors recently. 🤔 
I'll take a closer look to figure out what's happening, but in the meantime, this should help debug when things like this go wrong? 😅 