### PR TITLE
Remove redundant HTTP.start block

### DIFF
--- a/lib/mfynab/money_forward.rb
+++ b/lib/mfynab/money_forward.rb
@@ -33,23 +33,18 @@ module MFYNAB
     def download_csv(session_id:, path:, months:)
       month = Date.today
       month -= month.day - 1 # First day of month
+      months.times do
+        date_string = month.strftime("%Y-%m")
 
-      Net::HTTP.start(base_url.host, use_ssl: true) do |http|
-        http.response_body_encoding = Encoding::SJIS
+        logger.info("Downloading CSV for #{date_string}")
 
-        months.times do
-          date_string = month.strftime("%Y-%m")
-
-          logger.info("Downloading CSV for #{date_string}")
-
-          # FIXME: I don't really need to save the CSV files to disk anymore.
-          # Maybe just return parsed CSV data?
-          File.open(File.join(path, "#{date_string}.csv"), "wb") do |file|
-            file << download_csv_string(date: month, session_id: session_id)
-          end
-
-          month = month.prev_month
+        # FIXME: I don't really need to save the CSV files to disk anymore.
+        # Maybe just return parsed CSV data?
+        File.open(File.join(path, "#{date_string}.csv"), "wb") do |file|
+          file << download_csv_string(date: month, session_id: session_id)
         end
+
+        month = month.prev_month
       end
     end
 


### PR DESCRIPTION
## Why

It looks like only `download_csv_string` does any actual downloading:

https://github.com/davidstosik/moneyforward_ynab/blob/3c380e93e68fff559237d757060afae0a30df1f0/lib/mfynab/money_forward.rb?plain=1#L56-L60

Maybe we can omit the `HTTP.start` block from `download_csv`?
